### PR TITLE
#Bug fixes for type conversions extension methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,7 @@ All notable changes to this project will be documented in this file.
 > 🐛 **Bugfix** - Value convert error on Read/Write Coils.
 > ⌚ **Temporary** - Connection recreated on each request.
 > ⚡ **Feature** - Creation of all Read/Write methods in async version.
+
+## ⭐ [v0.1.1]
+> 🐛 **Bugfix** - Bug fix when performing value conversions in extension methods. When the ValueType passed in the WriteMultiplesHoldingAsync method was Byte, 
+it was always converted to ushort and in some cases it was giving a conversion error, which caused an error when sending data to the PLC.

--- a/Unwired.ModBus.Tcp/Extensions/IntegerExtensions.cs
+++ b/Unwired.ModBus.Tcp/Extensions/IntegerExtensions.cs
@@ -17,7 +17,7 @@ namespace Unwired.ModBus.Tcp.Extensions
             }
 
         }
-       /* public static byte[] ToByteArray(this ushort value, bool isWord = false, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
+        public static byte[] ToByteArray(this ushort value, bool isWord, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
         {
             try
             {
@@ -36,8 +36,20 @@ namespace Unwired.ModBus.Tcp.Extensions
                 return result;
             }
 
-        }*/
-        public static byte[] ToByteArray(this uint value, bool isWord = false, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
+        }
+        public static byte[] ToByteArray(this uint value, SwapTypeEnum swapType = SwapTypeEnum.NoSwap)
+        {
+            try
+            {
+                return BitConverter.GetBytes(value).Swap(swapType);
+            }
+            catch
+            {
+                return BitConverter.GetBytes(0).Swap(swapType);
+            }
+
+        }
+        public static byte[] ToByteArray(this uint value, bool isWord, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
         {
             try
             {
@@ -57,7 +69,7 @@ namespace Unwired.ModBus.Tcp.Extensions
             }
             
         }
-        public static byte[] ToByteArray(this int value, bool isWord = false, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
+        public static byte[] ToByteArray(this int value, bool isWord, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
         {
 
             try
@@ -78,6 +90,53 @@ namespace Unwired.ModBus.Tcp.Extensions
             }
 
         }
+        public static byte[] ToByteArray(this int value, SwapTypeEnum swapType = SwapTypeEnum.NoSwap)
+        {
+            try
+            {
+                return BitConverter.GetBytes(value).Swap(swapType);
+            }
+            catch
+            {
+                return BitConverter.GetBytes(0).Swap(swapType);
+            }
+
+        }
+        public static byte[] ToByteArray(this long value, bool isWord, EndiannessEnum endianness = EndiannessEnum.LittleEndian)
+        {
+
+            try
+            {
+                var result = BitConverter.GetBytes(value);
+                if (isWord)
+                    return BitConverter.GetBytes(value).ToSelectedEndianess(endianness);
+
+                return result;
+            }
+            catch
+            {
+                var result = BitConverter.GetBytes(0);
+                if (isWord)
+                    return BitConverter.GetBytes(value).ToSelectedEndianess(endianness);
+
+                return result;
+            }
+
+        }
+        public static byte[] ToByteArray(this long value, SwapTypeEnum swapType = SwapTypeEnum.NoSwap)
+        {
+            try
+            {
+                return BitConverter.GetBytes(value).Swap(swapType);
+            }
+            catch
+            {
+                return BitConverter.GetBytes(0).Swap(swapType);
+            }
+
+        }
+
+
         public static byte ToByte(this int value)
         {
 

--- a/Unwired.ModBus.Tcp/Extensions/ObjectExtension.cs
+++ b/Unwired.ModBus.Tcp/Extensions/ObjectExtension.cs
@@ -41,7 +41,100 @@ public static class ObjectExtension
 			return null;
 		}
 	}
-	public static float ToFloat(this object? value)
+    public static int ToInt(this object? value)
+    {
+        try
+        {
+            if(value == null)
+				return 0;
+
+			_ = int.TryParse(value.ToString(), out var result);
+			return result;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+    public static int? ToIntNullable(this object? value)
+    {
+        try
+        {
+            if (value is null)
+                return null;
+
+            _ = int.TryParse(value.ToString(), out var result);
+            return result;
+
+        }
+        catch
+        {
+            return null;
+        }
+    }
+    public static long ToLong(this object? value)
+    {
+        try
+        {
+            if (value == null)
+                return 0;
+
+            _ = long.TryParse(value.ToString(), out var result);
+            return result;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+    public static long? ToLongNullable(this object? value)
+    {
+        try
+        {
+            if (value is null)
+                return null;
+
+            _ = long.TryParse(value.ToString(), out var result);
+            return result;
+
+        }
+        catch
+        {
+            return null;
+        }
+    }
+    public static uint ToUInt(this object? value)
+    {
+        try
+        {
+            if (value == null)
+                return 0;
+
+            _ = uint.TryParse(value.ToString(), out var result);
+            return result;
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+    public static uint? ToUIntNullable(this object? value)
+    {
+        try
+        {
+            if (value is null)
+                return null;
+
+            _ = uint.TryParse(value.ToString(), out var result);
+            return result;
+
+        }
+        catch
+        {
+            return null;
+        }
+    }
+    public static float ToFloat(this object? value)
 	{
 		try
 		{
@@ -100,7 +193,22 @@ public static class ObjectExtension
             case ValueTypeEnum.DWord:
                 return value.ToDouble().ToByteArray(swapType);
             default:
-                return value.ToUShort().ToByteArray(swapType);
+
+				var type = value.GetType();
+				switch (type.Name.ToLower())
+				{
+					case "ushort":
+                        return value.ToUShort().ToByteArray(swapType);
+                    case "uint32":
+                        return value.ToUInt().ToByteArray(swapType);
+                    case "int32":
+                        return value.ToInt().ToByteArray(swapType);
+                    case "int64":
+                        return value.ToLong().ToByteArray(swapType);
+                    default:
+						break;
+				}
+				return value.ToUShort().ToByteArray(swapType);
         }
     }
 }

--- a/Unwired.ModBus.Tcp/Implementations/UnwiredModBusClient.cs
+++ b/Unwired.ModBus.Tcp/Implementations/UnwiredModBusClient.cs
@@ -1,9 +1,9 @@
 ﻿using System.Net;
 using System.Net.Sockets;
-using Unwired.ModBus.Tcp.Interfaces;
-using Unwired.ModBus.Tcp.Extensions;
-using Unwired.ModBus.Tcp.Enumarators;
 using System.Numerics;
+using Unwired.ModBus.Tcp.Enumarators;
+using Unwired.ModBus.Tcp.Extensions;
+using Unwired.ModBus.Tcp.Interfaces;
 
 
 namespace Unwired.ModBus.Tcp.Implementations;
@@ -817,21 +817,21 @@ public class UnwiredModBusClient : IUnwiredModBusClient, IDisposable
             if (valueType == ValueTypeEnum.DWord)
                 valueLength *= 4;
 
-            var transactionIdentifier = _transactionId.ToByteArray();
+            var transactionIdentifier = _transactionId.ToByteArray(valueType, valueType == ValueTypeEnum.Byte ? SwapTypeEnum.SwapBytes : _swapType);
             (var allDataLength, var dataContentLength, var byteCount, var quantityOfOutputs) = GetLength(function, valueLength, valueType);
-            var startAt = startingAddress.ToByteArray();
+            var startAt = startingAddress.ToByteArray(valueType, valueType == ValueTypeEnum.Byte ? SwapTypeEnum.SwapBytes : _swapType);
 
             var data = new byte[allDataLength];
-            data[0] = transactionIdentifier[1];
-            data[1] = transactionIdentifier[0];
+            data[0] = transactionIdentifier[0];
+            data[1] = transactionIdentifier[1];
             data[2] = _protocolIdentifier[1];
             data[3] = _protocolIdentifier[0];
             data[4] = dataContentLength[1];
             data[5] = dataContentLength[0];
             data[6] = _unitIdentifier;
             data[7] = ((int)function).ToByte();
-            data[8] = startAt[1];
-            data[9] = startAt[0];
+            data[8] = startAt[0];
+            data[9] = startAt[1];
             data[10] = quantityOfOutputs[1];
             data[11] = quantityOfOutputs[0];
             data[12] = byteCount;
@@ -949,7 +949,7 @@ public class UnwiredModBusClient : IUnwiredModBusClient, IDisposable
                     break;
 
                 case FunctionEnum.FC16:
-                    allDataLength = (13 + 2 + valuesLength * 2);
+                    allDataLength = (13 + valuesLength * 2);
                     dataContentLength = (7 + valuesLength * 2).ToByteArray();
                     break;
 

--- a/Unwired.ModBus.Tcp/Unwired.ModBus.Tcp.csproj
+++ b/Unwired.ModBus.Tcp/Unwired.ModBus.Tcp.csproj
@@ -6,7 +6,7 @@
 	<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup>
-	  <VersionSuffix>0.1.0</VersionSuffix>
+	  <VersionSuffix>0.1.1</VersionSuffix>
 	  <AssemblyVersion Condition=" '$(VersionSuffix)' == '' ">0.0.1</AssemblyVersion>
 	  <AssemblyVersion Condition=" '$(VersionSuffix)' != '' ">$(VersionSuffix)</AssemblyVersion>
 	  <Version Condition=" '$(VersionSuffix)' == '' ">0.0.1</Version>


### PR DESCRIPTION
Bug fix when performing value conversions in extension methods. When the ValueType passed in the WriteMultiplesHoldingAsync method was Byte, it was always converted to ushort and in some cases it was giving a conversion error, which caused an error when sending data to the PLC.